### PR TITLE
ENGDESK-18035: Support enabling/disabling strict fmt payload in SDP

### DIFF
--- a/libsofia-sip-ua/sdp/sdp_parse.c
+++ b/libsofia-sip-ua/sdp/sdp_parse.c
@@ -81,6 +81,7 @@ struct sdp_parser_s {
   unsigned   pr_insane : 1;
   unsigned   pr_c_missing : 1;
   unsigned   pr_config : 1;
+  unsigned   pr_fmt_strict : 1;
 };
 
 #define is_posdigit(c) ((c) >= '1' && (c) <= '9')
@@ -180,6 +181,8 @@ sdp_parse(su_home_t *home, char const msg[], issize_t msgsize, int flags)
       p->pr_c_missing = 1, p->pr_config = 1;
     p->pr_mode_manual = (flags & sdp_f_mode_manual) != 0;
     p->pr_session_mode = sdp_sendrecv;
+    if (flags & sdp_f_media_fmt_strict)
+      p->pr_fmt_strict = 1;
 
     parse_message(p);
 
@@ -1348,7 +1351,8 @@ static void parse_media(sdp_parser_t *p, char *r, sdp_media_t **result)
 
   /* RTP format list */
   if (*r && sdp_media_has_rtp(m)) {
-	  parse_payload(p, r, &m->m_rtpmaps);
+    if (!(m->m_port == 0 && !p->pr_fmt_strict)) 
+	    parse_payload(p, r, &m->m_rtpmaps);
 	  return;
   }
 

--- a/libsofia-sip-ua/sdp/sofia-sip/sdp.h
+++ b/libsofia-sip-ua/sdp/sofia-sip/sdp.h
@@ -531,7 +531,9 @@ enum sdp_parse_flags_e {
   /** Do not generate or parse SDP mode */
   sdp_f_mode_manual = 512,
   /** Always generate media-level mode attributes */
-  sdp_f_mode_always = 1024
+  sdp_f_mode_always = 1024,
+  /** Always validate FMT range even for inactive media stream */
+  sdp_f_media_fmt_strict = 2048
 };
 
 /** SDP parser handle. */

--- a/libsofia-sip-ua/soa/soa_tag.c
+++ b/libsofia-sip-ua/soa/soa_tag.c
@@ -649,3 +649,5 @@ tag_typedef_t soatag_ordered_user = BOOLTAG_TYPEDEF(ordered_user);
 tag_typedef_t soatag_reuse_rejected = BOOLTAG_TYPEDEF(reuse_rejected);
 
 tag_typedef_t soatag_sdp_print_flags = INTTAG_TYPEDEF(sdp_print_flags);
+
+tag_typedef_t soatag_sdp_media_strict_fmt = BOOLTAG_TYPEDEF(sdp_media_strict_fmt);

--- a/libsofia-sip-ua/soa/sofia-sip/soa_session.h
+++ b/libsofia-sip-ua/soa/sofia-sip/soa_session.h
@@ -224,6 +224,9 @@ struct soa_session
   /* SDP Print Flags */
   int ss_sdp_print_flag;
 
+  /* SDP Media FMT Strict */
+  unsigned  ss_sdp_media_fmt_strict:1;
+
   unsigned ss_srtp_enable:1,
     ss_srtp_confidentiality:1,
     ss_srtp_integrity:1;

--- a/libsofia-sip-ua/soa/sofia-sip/soa_tag.h
+++ b/libsofia-sip-ua/soa/sofia-sip/soa_tag.h
@@ -272,6 +272,13 @@ enum {
 #define SOATAG_SDP_PRINT_FLAGS_REF(x) soatag_sdp_print_flags_ref, tag_int_vr(&(x))
 SOFIAPUBVAR tag_typedef_t soatag_sdp_print_flags_ref;
 
+#define SOATAG_SDP_MEDIA_STRICT_FMT(x) soatag_sdp_media_strict_fmt, tag_bool_v(x)
+SOFIAPUBVAR tag_typedef_t soatag_sdp_media_strict_fmt;
+
+#define SOATAG_SDP_MEDIA_STRICT_FMT_REF(x) \
+  soatag_sdp_media_strict_fmt_ref, tag_bool_vr(&(x))
+SOFIAPUBVAR tag_typedef_t soatag_sdp_media_strict_fmt_ref;
+
 SOFIA_END_DECLS
 
 #endif /* SOA_TAG_H */


### PR DESCRIPTION
 - Strict FMT indicates that it will validate fmt even for inactive media stream
 - Non-strict FMT will not validate FMT when media is inactive