### PR TITLE
TELCORE-127: add nua_handle_skip_send_register API

### DIFF
--- a/libsofia-sip-ua/nua/nua.c
+++ b/libsofia-sip-ua/nua/nua.c
@@ -505,6 +505,16 @@ void nua_handle_skip_send_bye_set(nua_handle_t *nh, int val)
 	nh->nh_skip_send_bye = val;
 }
 
+int nua_handle_skip_send_register(nua_handle_t const *nh)
+{
+  return nh ? nh->nh_skip_send_register : 0;
+}
+
+void nua_handle_skip_send_register_set(nua_handle_t *nh, int val)
+{
+	nh->nh_skip_send_register = val;
+}
+
 /** Check if operation handle has an active call
  *
  * @param nh          Pointer to operation handle

--- a/libsofia-sip-ua/nua/nua_register.c
+++ b/libsofia-sip-ua/nua/nua_register.c
@@ -720,6 +720,21 @@ int nua_register_client_request(nua_client_request_t *cr,
 
   (void)nh;
 
+  /* Skip wire emission for REGISTER-method requests when
+   * nua_handle_skip_send_register is set. Covers the initial REGISTER,
+   * scheduled refresh REGISTERs (nua_register_usage_refresh), and the
+   * shutdown UNREGISTER (nua_register_usage_shutdown) — all three go
+   * through this crm_send. Mirrors the BYE skip pattern in
+   * nua_session.c. The dialog usage and client request are torn down
+   * locally via the synthesized 481 response.
+   *
+   * Scope: REGISTER-method only. The flag does NOT affect outbound
+   * keepalive OPTIONS (sent independently by outbound.c via
+   * nta_outgoing_mcreate). Intended use case is shared-AOR teardown
+   * where another node still holds the binding. */
+  if (nua_handle_skip_send_register(nh))
+    return nua_client_return(cr, SIP_481_NO_TRANSACTION, msg);
+
   /* Explicit empty (NULL) contact - used for CPL store/remove? */
   if (!contacts && cr->cr_has_contact)
     return nua_base_client_request(cr, msg, sip, tags);

--- a/libsofia-sip-ua/nua/nua_stack.h
+++ b/libsofia-sip-ua/nua/nua_stack.h
@@ -146,6 +146,7 @@ struct nua_handle_s
   unsigned        nh_offer_100rel:1;   /**< Offer 100rel */
   unsigned        nh_no_strip_routes:1;   /**< Do not strip route headers for mid dialog requests*/
   unsigned        nh_skip_send_bye:1;
+  unsigned        nh_skip_send_register:1; /**< Drop REGISTER refresh + shutdown UNREGISTER at wire-send */
 
   /* Call status */
   unsigned        nh_active_call:1;

--- a/libsofia-sip-ua/nua/sofia-sip/nua.h
+++ b/libsofia-sip-ua/nua/sofia-sip/nua.h
@@ -268,6 +268,10 @@ SOFIAPUBFUN int nua_handle_skip_send_bye(nua_handle_t const *nh);
 
 SOFIAPUBFUN void nua_handle_skip_send_bye_set(nua_handle_t *nh, int val);
 
+SOFIAPUBFUN int nua_handle_skip_send_register(nua_handle_t const *nh);
+
+SOFIAPUBFUN void nua_handle_skip_send_register_set(nua_handle_t *nh, int val);
+
 /** Get the remote address (From/To header) of operation handle */
 SOFIAPUBFUN sip_to_t const *nua_handle_remote(nua_handle_t const *nh);
 


### PR DESCRIPTION
## Summary

Adds `nua_handle_skip_send_register()` / `nua_handle_skip_send_register_set()` — a per-handle flag that suppresses REGISTER-method wire emission. Mirrors the existing `nua_handle_skip_send_bye` precedent.

When the flag is set, the following all return early via a synthesized `481` without touching the network:
- Initial REGISTER (`nua_stack_register` → `crm_send`)
- Refresh REGISTER (`nua_register_usage_refresh`)
- Shutdown UNREGISTER fired by `nua_handle_destroy()` on a REGED handle (`nua_register_usage_shutdown`)

Dialog usage and client request tear down locally; no SIP hits the wire.

## Why

mod_dynamic_gateway (Telnyx HA UAC) runs an active/standby model under BGP anycast: both peers register the same AOR with the registrar, and only one is "active" at a time. On HA demote, the demoted node must drop its local NUA handle without emitting any SIP — the active peer still owns the binding, and any UNREGISTER from the demoted node would tear it down and force a re-REGISTER on the peer.

Sofia today emits a final REGISTER with `Expires: 0` from `du_shutdown` regardless. This flag lets the application opt out for shared-AOR teardown.

## Scope

- REGISTER-method only.
- **Not** gated: RFC 5626 outbound NAT keepalive OPTIONS (sent separately via `outbound.c` / `nta_outgoing_mcreate`). That's a different concern (OPTIONS doesn't touch the AOR binding) and matches how the BYE skip is scoped (BYE only, not other in-dialog requests).

## Files

| File | Change |
|---|---|
| `libsofia-sip-ua/nua/sofia-sip/nua.h` | +4 — public prototypes |
| `libsofia-sip-ua/nua/nua.c` | +10 — getter/setter |
| `libsofia-sip-ua/nua/nua_stack.h` | +1 — `nh_skip_send_register:1` bit |
| `libsofia-sip-ua/nua/nua_register.c` | +15 — skip check in `nua_register_client_request` |

Total: 30 lines added.

## Test plan

- [x] Builds clean on `debian:bookworm` (autogen + configure + make).
- [x] New symbols `nua_handle_skip_send_register{,_set}` exported in `libsofia-sip-ua.so.0.6.0` (verified with `nm -D`).
- [x] No regression in existing `nua` tests (test target is empty — Sofia ships no automated nua-layer tests).
- [ ] End-to-end verification via mod_dynamic_gateway integration (separate PR, follow-up).