### PR TITLE
Sync deploy-development into master

### DIFF
--- a/libsofia-sip-ua/nua/check_session.c
+++ b/libsofia-sip-ua/nua/check_session.c
@@ -2280,6 +2280,35 @@ START_TEST(call_3_2_3)
 END_TEST
 
 
+START_TEST(call_3_2_4)
+{
+  nua_handle_t *nh;
+  struct message *invite;
+
+  S2_CASE("3.2.4", "Re-INVITE failure preserves dialog",
+	  "Re-INVITE fails with 500, dialog is preserved (no BYE)");
+  nh = nua_handle(nua, NULL, SIPTAG_TO(s2sip->aor),
+		  TAG_END());
+
+  invite_by_nua(nh, TAG_END());
+
+  nua_invite(nh, TAG_END());
+
+  fail_unless(s2_check_callstate(nua_callstate_calling));
+
+  invite = s2_sip_wait_for_request(SIP_METHOD_INVITE);
+  fail_if(!invite);
+  s2_sip_respond_to(invite, NULL, SIP_500_INTERNAL_SERVER_ERROR, TAG_END());
+  s2_sip_free_message(invite);
+  fail_unless(s2_sip_check_request(SIP_METHOD_ACK));
+  fail_unless_event(nua_r_invite, 500);
+  fail_unless(s2_check_callstate(nua_callstate_ready));
+
+  bye_by_nua(nh, TAG_END());
+}
+END_TEST
+
+
 TCase *invite_error_tcase(int threading)
 {
   TCase *tc = tcase_create("3 - Call Errors");
@@ -2290,6 +2319,7 @@ TCase *invite_error_tcase(int threading)
     tcase_add_test(tc, call_3_2_1);
     tcase_add_test(tc, call_3_2_2);
     tcase_add_test(tc, call_3_2_3);
+    tcase_add_test(tc, call_3_2_4);
     tcase_set_timeout(tc, 5);
   }
   return tc;

--- a/libsofia-sip-ua/nua/nua_session.c
+++ b/libsofia-sip-ua/nua/nua_session.c
@@ -1128,7 +1128,13 @@ static int nua_invite_client_report(nua_client_request_t *cr,
     next_state = nua_callstate_terminated;
   }
   else if (cr->cr_graceful && ss->ss_state >= nua_callstate_completing) {
-    next_state = nua_callstate_terminating;
+    if (!cr->cr_initial && status == 500) {
+      cr->cr_graceful = 0;
+      next_state = nua_callstate_init;
+    }
+    else {
+      next_state = nua_callstate_terminating;
+    }
   }
   else {
     next_state = nua_callstate_init;


### PR DESCRIPTION
Syncs the net deploy-development-only change into `master` while keeping `master` history clean.

Verification before opening:
- `origin/master`: `20edc18ade03`
- `origin/deploy-development`: `e82e0ee2d664`
- `git log --right-only --cherry-pick origin/master...origin/deploy-development` identified only TELCORE-212 as the net unapplied patch.
- Local cherry-pick was clean.
- Resulting tree matches `origin/deploy-development`.

Merge method requested: GitHub **Rebase and merge**. No force push.
